### PR TITLE
fix: bubble write notifications to all ancestor listeners

### DIFF
--- a/src/adapters/memory.ts
+++ b/src/adapters/memory.ts
@@ -51,11 +51,22 @@ export function createMemoryAdapter(): DbAdapter {
         node.data = data;
         const key = path[path.length - 1];
         notify(node, key);
-        // notify parent map listeners
-        if (path.length > 0) {
-          const parent = resolve(root, path.slice(0, -1));
-          for (const mcb of parent.mapListeners) {
-            try { mcb(data, key); } catch (e) { console.error('[unum/memory]', e); }
+        // Bubble up: notify map listeners and listeners on all ancestors.
+        // This ensures root.on() sees every write, no matter how deep.
+        for (let i = path.length - 1; i >= 0; i--) {
+          const ancestorPath = path.slice(0, i);
+          const ancestor = resolve(root, ancestorPath);
+          const childKey = path[i];
+          for (const mcb of ancestor.mapListeners) {
+            try { mcb(data, childKey); } catch (e) { console.error('[unum/memory]', e); }
+          }
+          // Also notify direct listeners on ancestors with the full path as key
+          // so root.on() receives (data, 'sprint/current') for deep writes.
+          if (ancestor !== node) {
+            const fullKey = path.join('/');
+            for (const lcb of ancestor.listeners) {
+              try { lcb(data, fullKey); } catch (e) { console.error('[unum/memory]', e); }
+            }
           }
         }
         cb?.(data, key);

--- a/tests/adapters.test.ts
+++ b/tests/adapters.test.ts
@@ -221,3 +221,58 @@ describe('pluresBind (subscription-based)', () => {
     profile.destroy();
   });
 });
+
+describe('memory adapter — event bubbling', () => {
+  it('root.on() receives child writes with full path as key', () => {
+    initDb(createMemoryAdapter());
+    const root = getRoot();
+    const events: Array<{ data: any; key: string }> = [];
+    root.on((data: any, key: string) => events.push({ data, key }));
+
+    root.get('sprint').get('current').put({ name: 'Sprint 1' });
+    root.get('notes').get('content').put('hello world');
+
+    expect(events.length).toBe(2);
+    expect(events[0]).toEqual({ data: { name: 'Sprint 1' }, key: 'sprint/current' });
+    expect(events[1]).toEqual({ data: 'hello world', key: 'notes/content' });
+    destroyDb();
+  });
+
+  it('root.on() receives deeply nested writes', () => {
+    initDb(createMemoryAdapter());
+    const root = getRoot();
+    const events: Array<{ key: string }> = [];
+    root.on((_data: any, key: string) => events.push({ key }));
+
+    root.get('a').get('b').get('c').get('d').put(42);
+
+    expect(events.length).toBe(1);
+    expect(events[0].key).toBe('a/b/c/d');
+    destroyDb();
+  });
+
+  it('intermediate node.on() also receives child writes', () => {
+    initDb(createMemoryAdapter());
+    const root = getRoot();
+    const events: Array<{ key: string }> = [];
+    root.get('sprint').on((_data: any, key: string) => events.push({ key }));
+
+    root.get('sprint').get('current').put({ name: 'test' });
+
+    // Direct child listener fires with key = 'current'
+    expect(events.some(e => e.key === 'sprint/current')).toBe(true);
+    destroyDb();
+  });
+
+  it('map listeners on root receive child writes', () => {
+    initDb(createMemoryAdapter());
+    const root = getRoot();
+    const events: Array<{ key: string }> = [];
+    root.map().on((_data: any, key: string) => events.push({ key }));
+
+    root.get('sprint').get('current').put({ name: 'test' });
+
+    expect(events.length).toBeGreaterThan(0);
+    destroyDb();
+  });
+});


### PR DESCRIPTION
## Problem
`root.on()` received **zero events** when children were written to via `root.get('sprint').get('current').put(data)`. Only the written node's direct listeners and the immediate parent's map listeners were notified.

This broke Chronos integration entirely — Chronos subscribes to `root.on()` to record all state changes, but saw nothing.

## Fix
`put()` now walks up the ancestor chain and notifies:
- **mapListeners** on each ancestor with the immediate child key
- **direct listeners** on each ancestor with the full joined path (e.g. `sprint/current`)

## Before/After
```
// Before: 0 events
root.on(cb); root.get('sprint').get('current').put({name: 'test'});

// After: cb('sprint/current', {name: 'test'})
```

## Chronos E2E verification
```
Stats: {nodes: 3, edges: 3, pending: 0}
Sprint history: 2 nodes
Notes history: 1 nodes
```

4 new tests, 31 total pass.