### PR TITLE
chore: apply org-standard automation files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,58 @@
+# Copilot Instructions
+
+## Organization Standards
+
+You are working in the **plures** organization. Before making changes, understand our standards.
+
+### Source of Truth
+- **Development guide:** https://github.com/plures/development-guide
+  - `standards/` — commit conventions, CI/CD, PR workflow, repo setup, code style
+  - `practices/` — copilot delegation, merge sweeps, local-first development
+  - `lessons-learned/` — past mistakes to avoid
+
+### Key Standards (DO NOT SKIP)
+
+**Conventional Commits** — all commit messages MUST follow:
+```
+<type>[optional scope]: <description>
+```
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`
+Breaking changes: add `!` after type or `BREAKING CHANGE:` in footer.
+
+**PR Titles** — use conventional commit format (they become the squash commit message).
+
+**Squash merge** — always. Clean single commit on `main`.
+
+**Tests required** — all new features need tests. All bug fixes need a failing test first.
+
+### Release Pipeline
+
+We use a **reusable release workflow** from `plures/.github`:
+
+```yaml
+name: Release
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      bump:
+        type: choice
+        options: [patch, minor, major]
+jobs:
+  release:
+    uses: plures/.github/.github/workflows/release-reusable.yml@main
+    with:
+      bump: ${{ inputs.bump || '' }}
+    secrets: inherit
+```
+
+The pipeline auto-detects project type and publishes to the appropriate registry.
+Version bumps are automatic from conventional commits. Do NOT manually bump versions.
+
+### What NOT to Do
+- Do NOT add `eslint-disable` — fix the underlying issue
+- Do NOT create sub-PRs that depend on other PRs
+- Do NOT touch files outside the requested scope
+- Do NOT manually bump version numbers
+- Do NOT skip tests or add `skip` annotations to make CI pass


### PR DESCRIPTION
## Org Standards Enforcement

This PR adds missing standard automation files:

- `.github/copilot-instructions.md` — Copilot coding instructions

These are required by the plures org standards. See [development-guide](https://github.com/plures/development-guide) for details.

---
_Auto-generated by [repo-standards](https://github.com/plures/.github/blob/main/.github/workflows/repo-standards.yml)_